### PR TITLE
Improve README with run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Asteroids Project From Boot.dev
+# Asteroids
+
+A simple remake of the classic arcade game written with [Pygame](https://www.pygame.org/). The codebase contains lightweight modules for the player ship, asteroids and projectiles. The main game loop lives in `main.py` which sets up sprite groups and handles updates and drawing each frame.
+
+## Project Structure
+
+- `constants.py` – game tuning values such as screen size and speeds
+- `circleshape.py` – base sprite used by the player, asteroids and shots
+- `player.py` – logic for controlling the ship and firing
+- `asteroid.py` – behaviour for individual asteroids
+- `asteroidfield.py` – spawns new asteroids over time
+- `shot.py` – projectile behaviour
+- `main.py` – entry point that runs the game loop
+
+## How to Run
+
+1. Install Python 3.13 or newer.
+2. Install dependencies (only Pygame is required):
+   ```bash
+   pip install pygame==2.6.1
+   ```
+3. Launch the game from the repository root:
+   ```bash
+   python main.py
+   ```
+
+Use **W/A/S/D** to thrust and rotate the ship and **SPACE** to fire. When your ship collides with an asteroid the program exits with "Game over!" in the console.


### PR DESCRIPTION
## Summary
- expand README with a project overview
- document modules that make up the game
- add instructions for installing dependencies and running the game

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862c1e05e7c832abbd1b1287e025afd